### PR TITLE
build(Makefile): modify build-libs target to exclude running tests be…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ lint-libs:
 	#./gradlew detekt
 
 build-libs:
-	./gradlew build --scan
+	./gradlew build publishToMavenLocal -x test
 
 test-libs:
 	./gradlew test
 
 package-libs: build-libs
-	./gradlew publishToMavenLocal publish
+	./gradlew publish
 
 version:
 	@VERSION=$$(cat VERSION); \


### PR DESCRIPTION
…fore publishing to Maven local

build(Makefile): modify package-libs target to only publish the libraries without running tests The changes were made to optimize the build process by excluding the test execution before publishing the libraries to Maven local. This helps to speed up the build process and reduce unnecessary overhead.