### PR TITLE
build(Makefile): rename 'package' target to 'publish' and add 'promot…

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,8 +11,10 @@ jobs:
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
+      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -7,8 +7,8 @@ jobs:
     uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: read

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: version
+VERSION = $(shell cat VERSION)
 
 lint: lint-libs
 build: build-libs
 test: test-libs
-package: package-libs
+publish: publish-libs
+promote: promote-libs
 
 docs:
 	echo 'No Docs'
@@ -13,14 +14,17 @@ lint-libs:
 	#./gradlew detekt
 
 build-libs:
-	./gradlew build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-libs:
 	./gradlew test
 
-package-libs: build-libs
-	./gradlew publish
+publish-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
 
+promote-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+
+.PHONY: version
 version:
-	@VERSION=$$(cat VERSION); \
-	echo "$$VERSION"
+	@echo "$(VERSION)"

--- a/gradle/publishing_common.gradle
+++ b/gradle/publishing_common.gradle
@@ -1,0 +1,24 @@
+ext {
+    signingKey = System.getenv("GPG_SIGNING_KEY") ?: ""
+    signingPassword = System.getenv("GPG_SIGNING_PASSWORD") ?: ""
+
+    repo = System.getenv("PKG_MAVEN_REPO") // github || sonatype_oss
+
+    repoUsername = repo == "github" ? System.getenv("PKG_GITHUB_USERNAME") : System.getenv("PKG_SONATYPE_OSS_USERNAME")
+    repoPassword = repo == "github" ? System.getenv("PKG_GITHUB_TOKEN") : System.getenv("PKG_SONATYPE_OSS_TOKEN")
+
+    githubRepoUrl = "https://maven.pkg.github.com/komune-io/${project.rootProject.name}"
+    releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+    snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots"
+    repoUrl = repo == "github" ? githubRepoUrl : (version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl)
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: 'javadoc') {
+    from javadoc.destinationDir
+    archiveClassifier = 'javadoc'
+}

--- a/gradle/publishing_module.gradle
+++ b/gradle/publishing_module.gradle
@@ -3,25 +3,12 @@
  */
 
 // Configures publishing of Maven artifacts to Bintray
-
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 apply from: project.rootProject.file('gradle/pom.gradle')
-
-def signingKey = System.getenv("GPG_SIGNING_KEY") ?: ""
-def signingPassword = System.getenv("GPG_SIGNING_PASSWORD") ?: ""
-
-task sourcesJar(type: Jar) {
-    from sourceSets.main.allJava
-    archiveClassifier = 'sources'
-}
-
-task javadocJar(type: Jar, dependsOn: 'javadoc') {
-    from javadoc.destinationDir
-    archiveClassifier = 'javadoc'
-}
+apply from: project.rootProject.file('gradle/publishing_common.gradle')
 
 afterEvaluate { Project project ->
     publishing {
@@ -38,19 +25,16 @@ afterEvaluate { Project project ->
         }
         repositories {
             maven {
-                url = "https://maven.pkg.github.com/komune-io/${project.rootProject.name}"
+                url = project.ext.repoUrl
                 credentials {
-                    username System.getenv("PKG_MAVEN_USERNAME")
-                    password System.getenv("PKG_MAVEN_TOKEN")
+                    username project.ext.repoUsername
+                    password project.ext.repoPassword
                 }
             }
         }
     }
     signing {
-        def key = signingKey
-        def password = signingPassword
-        useInMemoryPgpKeys(key, password)
+        useInMemoryPgpKeys(project.ext.signingKey, project.ext.signingPassword)
         sign publishing.publications.mavenJava
     }
-
 }

--- a/gradle/publishing_plugin.gradle
+++ b/gradle/publishing_plugin.gradle
@@ -8,25 +8,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 apply from: project.rootProject.file('gradle/pom.gradle')
-
-def signingKey = System.getenv("GPG_SIGNING_KEY") ?: ""
-def signingPassword = System.getenv("GPG_SIGNING_PASSWORD") ?: ""
-
-def sonatypeUsername = System.getenv("sonatypeUsername") ?: ""
-def sonatypePassword = System.getenv("sonatypePassword") ?: ""
-def releasesRepoUrl =  "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-def repoUrl = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-
-task sourcesJar(type: Jar) {
-    from sourceSets.main.allJava
-    archiveClassifier = 'sources'
-}
-
-task javadocJar(type: Jar, dependsOn: 'javadoc') {
-    from javadoc.destinationDir
-    archiveClassifier = 'javadoc'
-}
+apply from: project.rootProject.file('gradle/publishing_common.gradle')
 
 afterEvaluate { Project project ->
     publishing {
@@ -44,18 +26,15 @@ afterEvaluate { Project project ->
         }
         repositories {
             maven {
-                url = "https://maven.pkg.github.com/komune-io/${project.rootProject.name}"
+                url = project.ext.repoUrl
                 credentials {
-                    username System.getenv("PKG_MAVEN_USERNAME")
-                    password System.getenv("PKG_MAVEN_TOKEN")
+                    username project.ext.repoUsername
+                    password project.ext.repoPassword
                 }
             }
         }
     }
     signing {
-        def key = signingKey
-        def password = signingPassword
-        useInMemoryPgpKeys(key, password)
+        useInMemoryPgpKeys(project.ext.signingKey, project.ext.signingPassword)
     }
-
 }


### PR DESCRIPTION
…e' target to improve clarity and consistency in the build process

chore(gradle): extract common publishing configurations into a separate file 'publishing_common.gradle' to reduce duplication and improve maintainability The changes in the Makefile improve the clarity and consistency of the build process by renaming the 'package' target to 'publish' and adding a 'promote' target. This makes it easier for developers to understand the purpose of each target. The introduction of the 'publishing_common.gradle' file in the gradle directory centralizes common publishing configurations, reducing duplication and making it easier to maintain and update configurations across multiple gradle files.