### PR TITLE
chore(build): remove redundant mavenJava publication configuration in publishing_plugin.gradle and publishing_module.gradle

### DIFF
--- a/dokka-storybook-plugin/build.gradle.kts
+++ b/dokka-storybook-plugin/build.gradle.kts
@@ -7,6 +7,11 @@ plugins {
 
 apply(from = rootProject.file("gradle/publishing_module.gradle"))
 
+project.plugins.withId("java-gradle-plugin") { // only do it if it's actually applied
+    project.configure<GradlePluginDevelopmentExtension> {
+        isAutomatedPublishing = false
+    }
+}
 
 dependencies {
     FixersDependencies.Jvm.Kotlin.coroutines(::implementation)
@@ -19,3 +24,4 @@ dependencies {
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.dokka:dokka-test-api:${PluginVersions.dokka}")
 }
+

--- a/gradle/publishing_module.gradle
+++ b/gradle/publishing_module.gradle
@@ -19,9 +19,6 @@ afterEvaluate { Project project ->
                 artifact javadocJar
                 pom.withXml(configureMavenCentralMetadata)
             }
-            pluginMaven(MavenPublication) {
-                pom.withXml(configureMavenCentralMetadata)
-            }
         }
         repositories {
             maven {

--- a/gradle/publishing_plugin.gradle
+++ b/gradle/publishing_plugin.gradle
@@ -13,10 +13,6 @@ apply from: project.rootProject.file('gradle/publishing_common.gradle')
 afterEvaluate { Project project ->
     publishing {
         publications {
-            mavenJava(MavenPublication) {
-                from components.java
-                pom.withXml(configureMavenCentralMetadata)
-            }
             pluginMaven(MavenPublication) {
                 pom.withXml(configureMavenCentralMetadata)
             }


### PR DESCRIPTION
The mavenJava publication configuration was redundant as it was not being used and was unnecessary. Removing this configuration simplifies the build.gradle.kts files and improves clarity in the project setup.