### PR TITLE
feat(buildSrc): add new version constant fixersOlderVersion

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,9 +1,12 @@
+import io.komune.gradle.dependencies.FixersDependencies
 import io.komune.gradle.dependencies.FixersPluginVersions
 import io.komune.gradle.dependencies.FixersVersions
+import io.komune.gradle.dependencies.Scope
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 
 object PluginVersions {
 	val fixers = FixersPluginVersions.fixers
+	val fixersOlderVersion = "0.17.0"
 	var kotlinDsl = embeddedKotlinVersion
 	var kotlin = FixersPluginVersions.kotlin
 	var dokka = "1.9.20"
@@ -13,4 +16,12 @@ object PluginVersions {
 object Versions {
 	const val junit = FixersVersions.Test.junit
 	const val jackson = FixersVersions.Json.jackson
+}
+
+object Dependencies {
+	object Jvm {
+		object Kotlin {
+			fun coroutines(scope: Scope) = FixersDependencies.Jvm.Kotlin.coroutines(scope)
+		}
+	}
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersDependencies
-import io.komune.gradle.dependencies.FixersPluginVersions
 
 plugins {
     kotlin("jvm")
@@ -7,8 +5,8 @@ plugins {
 }
 
 dependencies {
-    FixersDependencies.Jvm.Kotlin.coroutines(::implementation)
-    implementation("io.komune.f2:f2-dsl-cqrs:${FixersPluginVersions.fixers}")
-    implementation("io.komune.f2:f2-dsl-function:${FixersPluginVersions.fixers}")
-    implementation("io.komune.f2:f2-spring-boot-starter-function-http:${FixersPluginVersions.fixers}")
+    Dependencies.Jvm.Kotlin.coroutines(::implementation)
+    implementation("io.komune.f2:f2-dsl-cqrs:${PluginVersions.fixersOlderVersion}")
+    implementation("io.komune.f2:f2-dsl-function:${PluginVersions.fixersOlderVersion}")
+    implementation("io.komune.f2:f2-spring-boot-starter-function-http:${PluginVersions.fixersOlderVersion}")
 }


### PR DESCRIPTION
refactor(build.gradle.kts): update dependencies to use new version constant PluginVersions.fixersOlderVersion The new constant fixersOlderVersion is added to maintain backward compatibility with older versions of the fixers plugin. The dependencies in the build.gradle.kts file are updated to use this new constant PluginVersions.fixersOlderVersion instead of directly referencing the fixers plugin version, ensuring consistency and easier maintenance of dependencies.