### PR TITLE
fix(gradle): update Gradle distribution URL to version 8.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The Gradle distribution URL in the gradle-wrapper.properties file has been updated to point to version 8.9 instead of 8.6. This change ensures that the project uses the latest version of Gradle for building and managing dependencies.