### PR TITLE
chore(dev.yml): remove deprecated Sonatype OSS credentials and update tag for publishing

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,9 +25,6 @@ jobs:
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
       PKG_GITHUB_USERNAME: ${{ github.actor }}
       PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
-      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
-
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
     permissions:
@@ -36,7 +33,7 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'publish_promote'
+      on-tag: 'stage_promote'
       make-file: 'make_docs.mk'
       with-chromatic: false
       storybook-dir: storybook
@@ -44,8 +41,12 @@ jobs:
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      #DEPRECATED
       DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
+      #DEPRECATED
       DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_STAGE_USERNAME: ${{ github.actor }}
+      DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
       DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
 


### PR DESCRIPTION
(dev.yml): add Docker stage credentials for improved deployment process The changes remove deprecated Sonatype OSS credentials to clean up the workflow and prevent confusion. The tag for publishing is updated from 'publish_promote' to 'stage_promote' to better reflect the intended deployment stage. Additionally, new Docker stage credentials are added to facilitate a smoother deployment process.