### PR TITLE
chore(build.gradle.kts): add mavenLocal() repository to build script for local dependency resolution

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 repositories {
     mavenCentral()
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
-    mavenLocal()
+    if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+        mavenLocal()
+    }
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 repositories {
     mavenCentral()
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
+    mavenLocal()
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,6 +30,7 @@ object Dependencies {
 
 fun RepositoryHandler.defaultRepo() {
 	mavenCentral()
+	mavenLocal()
 	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
 	maven { url = URI("https://repo.spring.io/milestone") }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,30 +7,31 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 
 object PluginVersions {
-	val fixers = FixersPluginVersions.fixers
-	val fixersOlderVersion = "0.17.0"
-	var kotlinDsl = embeddedKotlinVersion
-	var kotlin = FixersPluginVersions.kotlin
-	var dokka = "1.9.20"
-	const val gradlePublish = "1.2.0"
+    val fixers = FixersPluginVersions.fixers
+    val fixersOlderVersion = "0.17.0"
+    var kotlinDsl = embeddedKotlinVersion
+    var kotlin = FixersPluginVersions.kotlin
+    var dokka = "1.9.20"
+    const val gradlePublish = "1.2.0"
 }
 
 object Versions {
-	const val junit = FixersVersions.Test.junit
-	const val jackson = FixersVersions.Json.jackson
+    const val junit = FixersVersions.Test.junit
+    const val jackson = FixersVersions.Json.jackson
 }
 
 object Dependencies {
-	object Jvm {
-		object Kotlin {
-			fun coroutines(scope: Scope) = FixersDependencies.Jvm.Kotlin.coroutines(scope)
-		}
-	}
+    object Jvm {
+        object Kotlin {
+            fun coroutines(scope: Scope) = FixersDependencies.Jvm.Kotlin.coroutines(scope)
+        }
+    }
 }
 
 fun RepositoryHandler.defaultRepo() {
-	mavenCentral()
-	mavenLocal()
-	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
-	maven { url = URI("https://repo.spring.io/milestone") }
+    mavenCentral()
+    maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
+    if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+        mavenLocal()
+    }
 }


### PR DESCRIPTION
chore(Dependencies.kt): include mavenLocal() in default repository configuration for local dependency resolution Adding the mavenLocal() repository allows the build process to resolve dependencies that are available locally, improving development efficiency by enabling the use of locally published artifacts without needing to push them to a remote repository.