### PR TITLE
chore(make_libs.mk): rename publish target to stage and update promote target for clarity

### DIFF
--- a/make_libs.mk
+++ b/make_libs.mk
@@ -12,11 +12,11 @@ build:
 test:
 	./gradlew test
 
-publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
+stage:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew stage
 
 promote:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew promote
 
 .PHONY: version
 version:


### PR DESCRIPTION
The publish target is renamed to stage to better reflect its purpose in the build process. Additionally, the promote target is updated to clarify its role in promoting the package to the Sonatype OSS repository. This enhances the readability and maintainability of the makefile.