### PR TITLE
feat(ci): normalize secrets to FIXERS_PUBLISH_* namespace

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,13 +20,13 @@ jobs:
     with:
       make-file: 'infra/make/libs.mk'
     secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
     permissions:
@@ -41,12 +41,12 @@ jobs:
       storybook-dir: "storybook"
       storybook-static-dir: "storybook-static"
     secrets:
-      NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
-      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.FIXERS_DOCKER_HUB_PASSWORD }}
 
   sec:
     needs: libs
@@ -55,5 +55,5 @@ jobs:
       contents: write
       pull-requests: read
     secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,8 +41,7 @@ jobs:
       storybook-dir: "storybook"
       storybook-static-dir: "storybook-static"
     secrets:
-      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
+      FIXERS_CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}

--- a/infra/docker/storybook/Dockerfile
+++ b/infra/docker/storybook/Dockerfile
@@ -8,11 +8,11 @@ COPY storybook ./storybook
 
 WORKDIR /app/storybook
 
-ARG NPM_AUTH_TOKEN
+ARG FIXERS_PUBLISH_NPM_GITHUB_TOKEN
 RUN printf "\
 @komune-io:registry=https://npm.pkg.github.com\n\
 //npm.pkg.github.com/:_authToken=%s\n\
-" "${NPM_AUTH_TOKEN}" > .npmrc
+" "${FIXERS_PUBLISH_NPM_GITHUB_TOKEN}" > .npmrc
 
 
 RUN if [ ! -d "./storybook-static" ]; then \

--- a/infra/make/docs.mk
+++ b/infra/make/docs.mk
@@ -25,7 +25,7 @@ lint-docker-storybook:
 
 package-storybook:
 	@docker build --no-cache --platform=linux/amd64 \
-		--build-arg NPM_AUTH_TOKEN=${NPM_AUTH_TOKEN} \
+		--build-arg FIXERS_PUBLISH_NPM_GITHUB_TOKEN=${FIXERS_PUBLISH_NPM_GITHUB_TOKEN} \
 		-f ${STORYBOOK_DOCKERFILE} \
 		-t ${STORYBOOK_IMG} .
 


### PR DESCRIPTION
## Summary
- Rename libs + docs + sec caller pass-throughs + storybook Dockerfile/docs.mk NPM_AUTH_TOKEN rename
- Hard cutover: no legacy fallback

## Depends on
- komune-io/fixers-gradle#162 (fix/normalize-secrets) must merge first

## Test plan
- [ ] CI green after org secrets are created under FIXERS_* names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline and Docker build configurations for enhanced security practices in credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->